### PR TITLE
Implement IllegalArgumentException properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editor config
+/.idea
+
 # Logs
 logs
 *.log

--- a/src/java/lang/IllegalArgumentException.js
+++ b/src/java/lang/IllegalArgumentException.js
@@ -1,1 +1,8 @@
-export default class IllegalArgumentException {}
+export default class IllegalArgumentException extends Error {
+	constructor (message) {
+		super(message)
+		this.name = 'IllegalArgumentException'
+		this.message = message
+		this.stack = (new Error()).stack
+	}
+}


### PR DESCRIPTION
Throwing `IllegalArgumentException` was basically throwing an empty object. This PR attempts to implement it properly so that it functions like an error.

I was a little thrown off since it was inside a `java/lang` folder, so I might be doing something wrong here. I just pretty much copied this from [java/lang/RuntimeException.js](https://github.com/DenisCarriere/turf-jsts/blob/master/src/java/lang/RuntimeException.js).