### PR TITLE
update a license

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Topology",
     "Geometry"
   ],
-  "license": "(EDL-1.0 OR EPL-1.0)",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "@std/esm": "*",
     "chai": "*",


### PR DESCRIPTION
It looks like EDL-1.0 is Eclipse Distribution License which can be found here: http://www.eclipse.org/org/documents/edl-v10.php

The text of this license appears to be BSD-3-Clause, and I found the relevant discussion about adding EDL-1.0 as an official SPDX, but it was rejected because it is the same as BSD-3-Clause: https://lists.spdx.org/g/Spdx-legal/topic/request_for_adding_eclips/67981884

resolves #7 